### PR TITLE
form donation ok, intégrée avec form profile, le tout persisté en base

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -15,6 +15,6 @@
 }
 
 // Ne pas afficher les messages d'erreur de simple form
-.help-block {
-  display: none;
-}
+// .help-block {
+//   display: none;
+// }

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -7,16 +7,17 @@ class ProfilesController < ApplicationController
 
   def create
     @profile = Profile.new
-    @profile.amount_bracket = pparams[:amount_bracket].to_i
-    raise
-    if @profile.save
-      flash.now[:notice] = "Etape 1 ok!"
+    if pparams[:amount_bracket] != ""
+      @profile.amount_bracket = pparams[:amount_bracket].to_i
+      @profile.save
       redirect_to edit_profile_path(@profile)
     else
-      raise
-      flash.now[:alert] = @profile.errors[:amount_bracket][1]
+      flash.now[:alert] = "Veuillez sélectionner une des options proposées"
       render :new
     end
+  end
+
+  def edit
   end
 
   def update

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -3,6 +3,4 @@ class Profile < ApplicationRecord
   enum amount_bracket: ["moins de 50€", "moins de 100€", "moins de 200€",
     "moins de 500€", "500€ et plus" ]
 
-  validates :amount_bracket, presence: true, inclusion: { in: :amount_bracket,
-    message: "Vous devez sélectionner un des choix" }
 end

--- a/app/views/profiles/_form_donations.html.erb
+++ b/app/views/profiles/_form_donations.html.erb
@@ -1,5 +1,4 @@
 <%= simple_form_for @profile do |d| %>
-  <%= d.error_notification %>
   <%= d.input :amount_bracket,
         label: "Combien avez-vous donné en 2017 à des associations ?",
         collection: Profile.amount_brackets, as: :radio_buttons %>


### PR DESCRIPTION
Le formulaire de choix de montant de donation est bien bloqué avec message d'erreur jusqu'à ce que la sélection soit faite, auquel cas passe au formulaire d'entrée du full name et met à jour la base du profile ainsi créé.

Prochaine étape : insérer un formulaire entre les 2 pour les causes, avec un update de la base